### PR TITLE
Add moving items between Pantry & Shopping List pages

### DIFF
--- a/amplify/backend/api/kitchensyncc/schema.graphql
+++ b/amplify/backend/api/kitchensyncc/schema.graphql
@@ -12,10 +12,10 @@ type ItemList @model
   title: String!
   pantryDetails: PantryDetails,
   shoppingDetails: ShoppingDetails,
-  type: String!
   order: Int
 }
 type Ingredient {
+  id: ID!
   quantity: String
   unit: String
   ingredient: String!
@@ -23,6 +23,7 @@ type Ingredient {
   maxQty: String
   expires: String
   status: String
+  checked: Boolean
 }
 type PantryDetails {
   ingredients: [Ingredient],

--- a/components/FloatingButton.tsx
+++ b/components/FloatingButton.tsx
@@ -23,7 +23,7 @@ export default function FloatingButton (props) {
   const {action, label, icon} = labelFromAction(props.action)
   
   return (
-    <button className={styles[action]} title={label} >
+    <button className={styles[action]} title={label} onClick={props.onClick} >
       {icon}{label}
     </button>
   )

--- a/components/FloatingButton/UpdateShoppingList.tsx
+++ b/components/FloatingButton/UpdateShoppingList.tsx
@@ -9,14 +9,19 @@ export default function UpdateShoppingList () {
   const updateShoppingList = () => {
     const itemLists = state.itemLists;
     itemLists.forEach(itemList => {
-      const origin = itemList.shoppingDetails.ingredients
-      const destination = itemList.pantryDetails.ingredients
-      origin.forEach((item, index) => {
+      const updates = itemList.shoppingDetails.ingredients.reduce((updates, item) => {
         if (item.checked) {
-          const displacedItem = origin.splice(index, 1)
-          destination.push(...displacedItem)
+          updates.moved.push(item)
+        } else {
+          updates.unmoved.push(item)
         }
+        return updates;
+      }, {
+        moved: [],
+        unmoved: []
       })
+      itemList.pantryDetails.ingredients = updates.moved;
+      itemList.shoppingDetails.ingredients = updates.unmoved;
     })
     dispatch({type: "SET_ITEM_LISTS", payload: itemLists})
   }

--- a/components/FloatingButton/UpdateShoppingList.tsx
+++ b/components/FloatingButton/UpdateShoppingList.tsx
@@ -1,7 +1,7 @@
 import FloatingButton from './'
 import { FiCheck } from 'react-icons/fi'
 import { usePantry } from '../../src/user-context';
-
+import { gql_update_item_lists } from '../../src/graphql-actions';
 
 
 export default function UpdateShoppingList () {
@@ -23,7 +23,9 @@ export default function UpdateShoppingList () {
       itemList.pantryDetails.ingredients = itemList.pantryDetails.ingredients.concat(updates.moved);
       itemList.shoppingDetails.ingredients = updates.unmoved;
     })
-    dispatch({type: "SET_ITEM_LISTS", payload: itemLists})
+    gql_update_item_lists(itemLists).then(graphqlResponse => {
+      dispatch({type: "SET_ITEM_LISTS", payload: itemLists})
+    })
   }
   return (
     <button action="updateShoppingList" onClick={() => updateShoppingList()} label="Update List" icon={<FiCheck focusable="false"/>}>Update List</button>

--- a/components/FloatingButton/UpdateShoppingList.tsx
+++ b/components/FloatingButton/UpdateShoppingList.tsx
@@ -1,12 +1,26 @@
 import FloatingButton from './'
 import { FiCheck } from 'react-icons/fi'
+import { usePantry } from '../../src/user-context';
 
-const updateShoppingList = () => {
 
-}
 
 export default function UpdateShoppingList () {
+  const {state, dispatch} = usePantry();
+  const updateShoppingList = () => {
+    const itemLists = state.itemLists;
+    itemLists.forEach(itemList => {
+      const origin = itemList.shoppingDetails.ingredients
+      const destination = itemList.pantryDetails.ingredients
+      origin.forEach((item, index) => {
+        if (item.checked) {
+          const displacedItem = origin.splice(index, 1)
+          destination.push(...displacedItem)
+        }
+      })
+    })
+    dispatch({type: "SET_ITEM_LISTS", payload: itemLists})
+  }
   return (
-    <FloatingButton action={updateShoppingList} label="Update List" icon={<FiCheck focusable="false"/>} />
+    <button action="updateShoppingList" onClick={() => updateShoppingList()} label="Update List" icon={<FiCheck focusable="false"/>}>Update List</button>
   )
 }

--- a/components/FloatingButton/UpdateShoppingList.tsx
+++ b/components/FloatingButton/UpdateShoppingList.tsx
@@ -20,7 +20,7 @@ export default function UpdateShoppingList () {
         moved: [],
         unmoved: []
       })
-      itemList.pantryDetails.ingredients = updates.moved;
+      itemList.pantryDetails.ingredients = itemList.pantryDetails.ingredients.concat(updates.moved);
       itemList.shoppingDetails.ingredients = updates.unmoved;
     })
     dispatch({type: "SET_ITEM_LISTS", payload: itemLists})

--- a/components/FloatingButton/index.tsx
+++ b/components/FloatingButton/index.tsx
@@ -2,7 +2,7 @@ import styles from '../../styles/components/FloatingButton.module.css'
 
 export default function FloatingButton (props) {
    return (
-    <button className={styles[props.action.name]} title={props.label} onClick={props.action}>
+    <button  title={props.label} onClick={props.action}>
       {props.icon}{props.label}
     </button>
   )

--- a/components/ItemListFeed.tsx
+++ b/components/ItemListFeed.tsx
@@ -18,7 +18,7 @@ const ItemListFeed = (props) => {
       <ItemGroup key={itemList.id} title={itemList.title}>
         { itemList[props.type]?.ingredients.map((ingredient, index) => {
           return (
-            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status} index={index} key={index} itemListId={itemList.id}/>
+            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status} id={ingredient.id} key={ingredient.id} itemListId={itemList.id}/>
           )
         })}
         <NewItem itemListId={itemList.id} type={props.type} />

--- a/components/ItemListFeed.tsx
+++ b/components/ItemListFeed.tsx
@@ -18,7 +18,7 @@ const ItemListFeed = (props) => {
       <ItemGroup key={itemList.id} title={itemList.title}>
         { itemList[props.type]?.ingredients.map((ingredient, index) => {
           return (
-            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status} index={index} itemListId={itemList.id}/>
+            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status} index={index} key={index} itemListId={itemList.id}/>
           )
         })}
         <NewItem itemListId={itemList.id} type={props.type} />

--- a/components/ItemListFeed.tsx
+++ b/components/ItemListFeed.tsx
@@ -16,9 +16,9 @@ const ItemListFeed = (props) => {
   return <>{state.itemLists.map((itemList) => {
     return (
       <ItemGroup key={itemList.id} title={itemList.title}>
-        { itemList[props.type]?.ingredients.map((ingredient) => {
+        { itemList[props.type]?.ingredients.map((ingredient, index) => {
           return (
-            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status}/>
+            <Item type={props.type} quantity={ingredient.quantity} unit={ingredient.unit} ingredient={ingredient.ingredient} status={ingredient.status} index={index} itemListId={itemList.id}/>
           )
         })}
         <NewItem itemListId={itemList.id} type={props.type} />

--- a/components/ListItem/Item.tsx
+++ b/components/ListItem/Item.tsx
@@ -4,9 +4,9 @@ import PantryItem from "./PantryItem"
 const Item = (props) => {
   switch (props.type) {
     case 'shoppingDetails':
-      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.index} index={props.index} itemListId = {props.itemListId}/>
+      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.id} id={props.id} itemListId = {props.itemListId}/>
     case 'pantryDetails':
-      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.index} index={props.index} itemListId = {props.itemListId}/>
+      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.id} id={props.id} itemListId = {props.itemListId}/>
   }
 }
 

--- a/components/ListItem/Item.tsx
+++ b/components/ListItem/Item.tsx
@@ -4,9 +4,9 @@ import PantryItem from "./PantryItem"
 const Item = (props) => {
   switch (props.type) {
     case 'shoppingDetails':
-      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status}/>
+      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} index={props.index} itemListId = {props.itemListId}/>
     case 'pantryDetails':
-      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status}/>
+      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} index={props.index} itemListId = {props.itemListId}/>
   }
 }
 

--- a/components/ListItem/Item.tsx
+++ b/components/ListItem/Item.tsx
@@ -4,9 +4,9 @@ import PantryItem from "./PantryItem"
 const Item = (props) => {
   switch (props.type) {
     case 'shoppingDetails':
-      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} index={props.index} itemListId = {props.itemListId}/>
+      return <ShoppingListItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.index} index={props.index} itemListId = {props.itemListId}/>
     case 'pantryDetails':
-      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} index={props.index} itemListId = {props.itemListId}/>
+      return <PantryItem quantity={props.quantity} unit={props.unit} ingredient={props.ingredient} status={props.status} key={props.index} index={props.index} itemListId = {props.itemListId}/>
   }
 }
 

--- a/components/ListItem/NewItem.jsx
+++ b/components/ListItem/NewItem.jsx
@@ -6,7 +6,7 @@ import {usePantry} from '../../src/user-context'
 
 export default function NewItem (props) {
   const {state, dispatch} = usePantry();
-  const [title, setTitle] = useState<any>({
+  const [title, setTitle] = useState({
     title: "",
   });
   const addItem = async (event) => {
@@ -20,7 +20,7 @@ export default function NewItem (props) {
       gql_add_item(state, input).then(graphqlResponse => {
         const responseData = graphqlResponse.data.updateItemList;
         responseData.type = input.type;
-        dispatch({type: "ADD_ITEM", payload: responseData})
+        dispatch({type: "UPDATE_ITEM_LIST", payload: responseData})
       })
     } catch (err) {
       console.log("Nope:", err)

--- a/components/ListItem/NewItem.jsx
+++ b/components/ListItem/NewItem.jsx
@@ -13,6 +13,7 @@ export default function NewItem (props) {
     event.preventDefault();
     try {
       const input = {
+        ingredientId: Date.now().toString(),
         itemListId: props.itemListId,
         ingredient: event.target.title.value,
         type: props.type

--- a/components/ListItem/PantryItem.tsx
+++ b/components/ListItem/PantryItem.tsx
@@ -89,6 +89,6 @@ const reorderPantryItem = (state, dispatch, itemListId, index) => {
   }).then(graphqlResponse => {
     const responseData = graphqlResponse.data.updateItemList;
     responseData.type = "pantryDetails";
-    dispatch({type: "ADD_ITEM", payload: responseData})
+    dispatch({type: "UPDATE_ITEM_LIST", payload: responseData})
   })
 }

--- a/components/ListItem/PantryItem.tsx
+++ b/components/ListItem/PantryItem.tsx
@@ -88,7 +88,6 @@ const reorderPantryItem = (state, dispatch, itemListId, ingredientId) => {
     destination: "shoppingDetails"
   }).then(graphqlResponse => {
     const responseData = graphqlResponse.data.updateItemList;
-    responseData.type = "pantryDetails";
     dispatch({type: "UPDATE_ITEM_LIST", payload: responseData})
   })
 }

--- a/components/ListItem/PantryItem.tsx
+++ b/components/ListItem/PantryItem.tsx
@@ -7,7 +7,7 @@ import { FiEdit, FiRepeat } from "react-icons/fi";
 import {usePantry} from "../../src/user-context"
 import { gql_move_ingredient } from "../../src/graphql-actions"
 
-const PantryActions = (props: { className: string; editing: any; index: number; itemListId: string }) => {
+const PantryActions = (props: { className: string; editing: any; id: string; itemListId: string }) => {
   const {state, dispatch} = usePantry();
   const {
     // @ts-ignore: Initializer provides no value for this binding element and the binding element has no default value.
@@ -22,7 +22,7 @@ const PantryActions = (props: { className: string; editing: any; index: number; 
         <FiEdit focusable="false" />
         Edit
       </button>
-      <button onClick={() => reorderPantryItem(state, dispatch, props.itemListId, props.index)}>
+      <button onClick={() => reorderPantryItem(state, dispatch, props.itemListId, props.id)}>
         <FiRepeat focusable="false" />
         Reorder
       </button>
@@ -45,7 +45,7 @@ export default function PantryItem(props: IngredientInterface) {
   const [editing, setEditing] = useState(false);
 
   return (
-    <li className={styles.ingredient} key={props.index}>
+    <li className={styles.ingredient} key={props.id}>
       <CollapsiblePanel
         title={props.ingredient}
         status={props.status}
@@ -71,7 +71,7 @@ export default function PantryItem(props: IngredientInterface) {
         <PantryActions
           className={styles.actions}
           editing={{ editing: [editing, setEditing] }}
-          index={props.index}
+          id={props.id}
           itemListId={props.itemListId}
         />
       </CollapsiblePanel>
@@ -79,11 +79,11 @@ export default function PantryItem(props: IngredientInterface) {
   );
 }
 
-const reorderPantryItem = (state, dispatch, itemListId, index) => {
+const reorderPantryItem = (state, dispatch, itemListId, ingredientId) => {
   
   gql_move_ingredient(state, {
     itemListId: itemListId,
-    itemToMove: index,
+    ingredientId: ingredientId,
     origin: "pantryDetails",
     destination: "shoppingDetails"
   }).then(graphqlResponse => {

--- a/components/ListItem/PantryItem.tsx
+++ b/components/ListItem/PantryItem.tsx
@@ -4,8 +4,11 @@ import CollapsiblePanel from "../CollapsiblePanel";
 import styles from "../../styles/components/Ingredient.module.css";
 import EditableField from "../EditableField";
 import { FiEdit, FiRepeat } from "react-icons/fi";
+import {usePantry} from "../../src/user-context"
+import { gql_move_ingredient } from "../../src/graphql-actions"
 
-const PantryActions = (props: { className: string; editing: any }) => {
+const PantryActions = (props: { className: string; editing: any; index: number; itemListId: string }) => {
+  const {state, dispatch} = usePantry();
   const {
     // @ts-ignore: Initializer provides no value for this binding element and the binding element has no default value.
     editing: [editing, setEditing],
@@ -19,7 +22,7 @@ const PantryActions = (props: { className: string; editing: any }) => {
         <FiEdit focusable="false" />
         Edit
       </button>
-      <button>
+      <button onClick={() => reorderPantryItem(state, dispatch, props.itemListId, props.index)}>
         <FiRepeat focusable="false" />
         Reorder
       </button>
@@ -42,7 +45,7 @@ export default function PantryItem(props: IngredientInterface) {
   const [editing, setEditing] = useState(false);
 
   return (
-    <li className={styles.ingredient}>
+    <li className={styles.ingredient} key={props.index}>
       <CollapsiblePanel
         title={props.ingredient}
         status={props.status}
@@ -61,15 +64,27 @@ export default function PantryItem(props: IngredientInterface) {
           <li>
             Expires: 
             <EditableField label="Expires" type="date" editing={editing}>
-              1970-01-01
+              {props.expires}
             </EditableField>
           </li>
         </ul>
         <PantryActions
           className={styles.actions}
           editing={{ editing: [editing, setEditing] }}
+          index={props.index}
+          itemListId={props.itemListId}
         />
       </CollapsiblePanel>
     </li>
   );
+}
+
+const reorderPantryItem = (state, dispatch, itemListId, index) => {
+  
+  console.log(gql_move_ingredient(state, {
+    itemListId: itemListId,
+    itemToMove: index,
+    origin: "pantryDetails",
+    destination: "shoppingDetails"
+  }))
 }

--- a/components/ListItem/PantryItem.tsx
+++ b/components/ListItem/PantryItem.tsx
@@ -81,10 +81,14 @@ export default function PantryItem(props: IngredientInterface) {
 
 const reorderPantryItem = (state, dispatch, itemListId, index) => {
   
-  console.log(gql_move_ingredient(state, {
+  gql_move_ingredient(state, {
     itemListId: itemListId,
     itemToMove: index,
     origin: "pantryDetails",
     destination: "shoppingDetails"
-  }))
+  }).then(graphqlResponse => {
+    const responseData = graphqlResponse.data.updateItemList;
+    responseData.type = "pantryDetails";
+    dispatch({type: "ADD_ITEM", payload: responseData})
+  })
 }

--- a/components/ListItem/ShoppingListItem.tsx
+++ b/components/ListItem/ShoppingListItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { usePantry } from "../../src/user-context";
 import { Ingredient as IngredientInterface } from "../../types";
 import styles from "../../styles/components/ShoppingListItem.module.css";
@@ -7,6 +7,11 @@ import { FiSquare, FiCheckSquare } from "react-icons/fi"
 export default function ShoppingListItem(props: IngredientInterface) {
   const [checked, setChecked] = useState(false);
   const {state, dispatch} = usePantry();
+  useEffect(() => {
+    const listToUpdate = state.itemLists.find(list => list.id === props.itemListId)
+    const ingredientToUpdate = listToUpdate.shoppingDetails.ingredients.find(ingredient => ingredient.id === props.id)
+    setChecked(ingredientToUpdate.checked)
+  }, [])
 
   return (
     <li className={styles.listItem} key={props.id}>

--- a/components/ListItem/ShoppingListItem.tsx
+++ b/components/ListItem/ShoppingListItem.tsx
@@ -9,7 +9,7 @@ export default function ShoppingListItem(props: IngredientInterface) {
   return (
     <li className={styles.listItem} key={props.index}>
       <label className={checked ? styles.checked : ""}>
-        {checked ? <FiCheckSquare focusable="false" title={(checked) ? "Unchecked" : "Checked"} /> : <FiSquare/>}
+        {checked ? <FiCheckSquare focusable="false" title="Checked" /> : <FiSquare focusable="false" title="Unchecked"/>}
         <input className="sr-only"
           type="checkbox"
           checked={checked}

--- a/components/ListItem/ShoppingListItem.tsx
+++ b/components/ListItem/ShoppingListItem.tsx
@@ -7,7 +7,7 @@ export default function ShoppingListItem(props: IngredientInterface) {
   const [checked, setChecked] = useState(false);
 
   return (
-    <li className={styles.listItem}>
+    <li className={styles.listItem} key={props.index}>
       <label className={checked ? styles.checked : ""}>
         {checked ? <FiCheckSquare focusable="false" title={(checked) ? "Unchecked" : "Checked"} /> : <FiSquare/>}
         <input className="sr-only"

--- a/components/ListItem/ShoppingListItem.tsx
+++ b/components/ListItem/ShoppingListItem.tsx
@@ -1,19 +1,28 @@
 import { useState } from "react";
+import { usePantry } from "../../src/user-context";
 import { Ingredient as IngredientInterface } from "../../types";
 import styles from "../../styles/components/ShoppingListItem.module.css";
 import { FiSquare, FiCheckSquare } from "react-icons/fi"
 
 export default function ShoppingListItem(props: IngredientInterface) {
   const [checked, setChecked] = useState(false);
+  const {state, dispatch} = usePantry();
 
   return (
-    <li className={styles.listItem} key={props.index}>
+    <li className={styles.listItem} key={props.id}>
       <label className={checked ? styles.checked : ""}>
         {checked ? <FiCheckSquare focusable="false" title="Checked" /> : <FiSquare focusable="false" title="Unchecked"/>}
         <input className="sr-only"
           type="checkbox"
           checked={checked}
-          onChange={() => setChecked(!checked)}
+          onChange={() => {
+            setChecked(!checked)
+            dispatch({type: 'UPDATE_INGREDIENT_CHECKBOX', payload: {
+              itemListId: props.itemListId,
+              ingredientId: props.id,
+              checked: !checked
+            }})
+          }}
         />
         <span>{props.ingredient}</span>
       </label>

--- a/components/NewItemList.jsx
+++ b/components/NewItemList.jsx
@@ -7,7 +7,7 @@ import {usePantry} from '../src/user-context'
 
 export default function NewItemList (props) {
   const {dispatch} = usePantry();
-  const [title, setTitle] = useState<any>({
+  const [title, setTitle] = useState({
     title: "",
   });
   const addList = async (event) => {
@@ -16,7 +16,6 @@ export default function NewItemList (props) {
       const graphqlResponse = await API.graphql(graphqlOperation(createItemList, {
         input: {
           title: event.target.title.value,
-          type: "shoppingList",
           pantryDetails: {
             ingredients: []
           },

--- a/pages/list.tsx
+++ b/pages/list.tsx
@@ -4,23 +4,17 @@ import ShoppingListItem from "../components/ListItem/ShoppingListItem";
 import FloatingButton from "../components/FloatingButton";
 import NewItemList from "../components/NewItemList";
 import ItemListFeed from "../components/ItemListFeed"
+import UpdateShoppingList from "../components/FloatingButton/UpdateShoppingList";
 
 export default function List() {  
   return (
     <Layout title="Shopping List">
-      <ItemGroup title="Produce">
-        <ShoppingListItem quantity="1" unit="cup" ingredient="sugar" />
-        <ShoppingListItem quantity="1" unit="cup" ingredient="sour cream" />
-        <ShoppingListItem quantity="1" unit="cup" ingredient="Saffron" />
-        <ShoppingListItem quantity="1" unit="cup" ingredient="Salt" />
-      </ItemGroup>
-      <h2>Real Data</h2>
       <ItemListFeed type="shoppingDetails"/>
       <h2>Add a New List</h2>
       <NewItemList />
       <div className="floating-button-container">
         <FloatingButton action="editShoppingList" />
-        <FloatingButton action="updateShoppingList" />
+        <UpdateShoppingList/>
       </div>
     </Layout>
   );

--- a/pages/pantry.tsx
+++ b/pages/pantry.tsx
@@ -7,13 +7,6 @@ import ItemListFeed from "../components/ItemListFeed"
 export default function Pantry(){
   return (
     <Layout title="Pantry">
-      <ItemGroup title="Produce">
-        <PantryItem quantity="1" unit="cup" ingredient="sugar" status="ok"/>
-        <PantryItem quantity="1" unit="cup" ingredient="sour cream" status="warning"/>
-        <PantryItem quantity="1" unit="cup" ingredient="Saffron" status="critical"/>
-        <PantryItem quantity="1" unit="cup" ingredient="Salt"/>
-      </ItemGroup>
-      <h2>Real Data</h2>
       <ItemListFeed type="pantryDetails"/>
       <div className="floating-button-container">
         <AddToPantry />

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -27,7 +27,6 @@ export const gql_get_item_lists = async () => {
 };
 
 export async function gql_add_item (state, input) {
-  console.log(input);
   const currentItemList = state.itemLists.find(itemList => itemList.id === input.itemListId)
   try {
     return await API.graphql(graphqlOperation(updateItemList, {
@@ -53,11 +52,21 @@ export const gql_move_ingredient = async (state, payload) => {
   const currentItemList = state.itemLists.find(itemList => itemList.id === payload.itemListId)
   const origin = currentItemList[payload.origin].ingredients
   const destination = currentItemList[payload.destination].ingredients
-  const displacedItem = origin.splice(payload.itemToMove, 1)
-  destination.push(...displacedItem)
+  const ingredientToMove = origin.find(ingredient => ingredient.id == payload.ingredientId)
+  const remainingIngredients = origin.filter(ingredient =>  ingredient != ingredientToMove)
+  const updatedDestination = [...destination, ingredientToMove]
+  const updatedItemList = {
+    ...currentItemList,
+    [payload.origin]: { // this is getting ignored
+      ingredients: remainingIngredients
+    },
+    [payload.destination]: { // this is getting ignored
+      ingredients: updatedDestination
+    }
+  }
   try {
     return await API.graphql(graphqlOperation(updateItemList, {
-      input: currentItemList
+      input: updatedItemList
     }))
   } catch (err) {
     console.log("GraphQL Error:", err)

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -57,10 +57,10 @@ export const gql_move_ingredient = async (state, payload) => {
   const updatedDestination = [...destination, ingredientToMove]
   const updatedItemList = {
     ...currentItemList,
-    [payload.origin]: { // this is getting ignored
+    pantryDetails: { // this is getting ignored
       ingredients: remainingIngredients
     },
-    [payload.destination]: { // this is getting ignored
+    shoppingDetails: { // this is getting ignored
       ingredients: updatedDestination
     }
   }

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -94,3 +94,25 @@ export const gql_update_shopping_list = async (state, payload) => {
     console.log("GraphQL Error:", err)
   }
 }
+
+export const gql_move_checked_items = async (state, input) => {
+    const itemLists = state.itemLists;
+    itemLists.forEach(itemList => {
+      const origin = itemList.shoppingDetails.ingredients
+      const destination = itemList.pantryDetails.ingredients
+      itemList.forEach((item, index) => {
+        if (item.checked) {
+          const displacedItem = origin.splice(index, 1)
+          destination.push(...displacedItem)
+        }
+      })
+      
+    })
+    try {
+      return await API.graphql(graphqlOperation(updateItemList, {
+        input: itemLists
+      }))
+    } catch (err) {
+      console.log("GraphQL Error:", err)
+    }
+}

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -73,35 +73,16 @@ export const gql_move_ingredient = async (state, payload) => {
   }
 }
 
-export const gql_update_shopping_list = async (state, payload) => {
-  // Get all lists that have checked items + which of their items are checked
-  // Or, we could just go through each itemList, check its checked status, and update them 1 by one in a big forEach?
-  const listsToUpdate = state.itemLists.reduce((listsToUpdate, itemList) => {
-    const checkedItems = itemList.shoppingDetails.ingredients.filter(ingredient => ingredient.checked === true)
-    if (checkedItems) return listsToUpdate.push({
-      id: itemList.id,
-      checkedItems: checkedItems
-    })
-  }, [])
-  // For each list: Move the checked items to pantryDetails. Update shoppingDetails to only have unchecked items.
-  listsToUpdate.forEach(itemList => {
-    const currentItemList = state.itemLists.find(stateItemList => stateItemList.id === itemList.id)
-    const origin = currentItemList.shoppingDetails.ingredients
-    const destination = currentItemList.pantryDetails.ingredients
-    
-    // Right now, checkedItems is a separate array so the keys of the array we're iterating over here will be meaningless.
-    // Do we want to add IDs for each ingredient created? Could be as simple as a Date(), added to the DB, or the DB can handle it.
-    // Or, do we want to change how we work with the checked items so that we don't create a second array?
-
+export const gql_update_item_lists = async (payload) => {
+  payload.forEach (async (itemList) => {
+    try {
+      return await API.graphql(graphqlOperation(updateItemList, {
+        input: itemList
+      }))
+    } catch (err) {
+      console.log("GraphQL Error:", err)
+    }
   })
-
-  try {
-    return await API.graphql(graphqlOperation(updateItemList, {
-      input: listsToUpdate
-    }))
-  } catch (err) {
-    console.log("GraphQL Error:", err)
-  }
 }
 
 export const gql_move_checked_items = async (state, input) => {

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -57,10 +57,10 @@ export const gql_move_ingredient = async (state, payload) => {
   const updatedDestination = [...destination, ingredientToMove]
   const updatedItemList = {
     ...currentItemList,
-    pantryDetails: { // this is getting ignored
+    [payload.origin]: { // this is getting ignored
       ingredients: remainingIngredients
     },
-    shoppingDetails: { // this is getting ignored
+    [payload.destination]: { // this is getting ignored
       ingredients: updatedDestination
     }
   }

--- a/src/graphql-actions.js
+++ b/src/graphql-actions.js
@@ -47,3 +47,18 @@ export async function gql_add_item (state, payload) {
   }
 }
 
+export const gql_move_ingredient = async (state, payload) => {
+  const currentItemList = state.itemLists.find(itemList => itemList.id === payload.itemListId)
+  const origin = currentItemList[payload.origin].ingredients
+  const destination = currentItemList[payload.destination].ingredients
+  const displacedItem = origin.splice(payload.itemToMove, 1)
+  destination.push(...displacedItem)
+  // Send the updated array to graphQL
+  try {
+    return await API.graphql(graphqlOperation(updateItemList, {
+      input: currentItemList
+    }))
+  } catch (err) {
+    console.log("GraphQL Error:", err)
+  }
+}

--- a/src/graphql/custom-mutations.ts
+++ b/src/graphql/custom-mutations.ts
@@ -7,11 +7,13 @@ export const updateItemList = /* GraphQL */ `
       id
       pantryDetails {
         ingredients {
+          id
           ingredient
         }
       }
       shoppingDetails {
         ingredients {
+          id
           ingredient
         }
       }

--- a/src/graphql/custom-queries.ts
+++ b/src/graphql/custom-queries.ts
@@ -11,6 +11,7 @@ export const listItemLists = /* GraphQL */ `
         order
         pantryDetails {
           ingredients {
+            id
             quantity
             unit
             ingredient
@@ -18,9 +19,11 @@ export const listItemLists = /* GraphQL */ `
         }
         shoppingDetails {
           ingredients {
+            id
             quantity
             unit
             ingredient
+            checked
           }
         }
       }

--- a/src/graphql/custom-queries.ts
+++ b/src/graphql/custom-queries.ts
@@ -9,7 +9,6 @@ export const listItemLists = /* GraphQL */ `
         id
         title
         order
-        createdAt
         pantryDetails {
           ingredients {
             quantity
@@ -24,7 +23,6 @@ export const listItemLists = /* GraphQL */ `
             ingredient
           }
         }
-        owner
       }
       nextToken
     }

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -12,8 +12,6 @@ export const createRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -21,6 +19,7 @@ export const createRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -39,8 +38,6 @@ export const updateRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -48,6 +45,7 @@ export const updateRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -66,8 +64,6 @@ export const deleteRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -75,6 +71,7 @@ export const deleteRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -97,7 +94,6 @@ export const createItemList = /* GraphQL */ `
       shoppingDetails {
         order
       }
-      type
       order
       createdAt
       updatedAt
@@ -114,16 +110,11 @@ export const updateItemList = /* GraphQL */ `
       id
       title
       pantryDetails {
-        ingredients {
-          ingredient
-        }
+        order
       }
       shoppingDetails {
-        ingredients {
-          ingredient
-        }
+        order
       }
-      type
       order
       createdAt
       updatedAt
@@ -145,7 +136,6 @@ export const deleteItemList = /* GraphQL */ `
       shoppingDetails {
         order
       }
-      type
       order
       createdAt
       updatedAt

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -9,8 +9,6 @@ export const getRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -18,6 +16,7 @@ export const getRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -56,7 +55,6 @@ export const getItemList = /* GraphQL */ `
       shoppingDetails {
         order
       }
-      type
       order
       createdAt
       updatedAt
@@ -74,17 +72,9 @@ export const listItemLists = /* GraphQL */ `
       items {
         id
         title
-        type
         order
         createdAt
         updatedAt
-        shoppingDetails {
-          ingredients {
-            quantity
-            unit
-            ingredient
-          }
-        }
         owner
       }
       nextToken

--- a/src/graphql/subscriptions.ts
+++ b/src/graphql/subscriptions.ts
@@ -9,8 +9,6 @@ export const onCreateRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -18,6 +16,7 @@ export const onCreateRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -33,8 +32,6 @@ export const onUpdateRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -42,6 +39,7 @@ export const onUpdateRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -57,8 +55,6 @@ export const onDeleteRecipe = /* GraphQL */ `
       url
       ingredients {
         id
-        recipeID
-        listID
         quantity
         unit
         ingredient
@@ -66,6 +62,7 @@ export const onDeleteRecipe = /* GraphQL */ `
         maxQty
         expires
         status
+        checked
       }
       status
       createdAt
@@ -79,6 +76,16 @@ export const onCreateItemList = /* GraphQL */ `
     onCreateItemList(owner: $owner) {
       id
       title
+      pantryDetails {
+        order
+      }
+      shoppingDetails {
+        order
+      }
+      order
+      createdAt
+      updatedAt
+      owner
     }
   }
 `;
@@ -93,7 +100,6 @@ export const onUpdateItemList = /* GraphQL */ `
       shoppingDetails {
         order
       }
-      type
       order
       createdAt
       updatedAt
@@ -112,7 +118,6 @@ export const onDeleteItemList = /* GraphQL */ `
       shoppingDetails {
         order
       }
-      type
       order
       createdAt
       updatedAt

--- a/src/user-context.js
+++ b/src/user-context.js
@@ -26,7 +26,7 @@ function userDataReducer (state, action) {
           ...action.payload
         ]
       }
-    case "ADD_ITEM":
+    case "UPDATE_ITEM_LIST":
       const listToUpdate = state.itemLists.find(list => list.id === action.payload.id)
       listToUpdate[action.payload.type].ingredients = action.payload[action.payload.type].ingredients;
       return {

--- a/src/user-context.js
+++ b/src/user-context.js
@@ -26,13 +26,24 @@ function userDataReducer (state, action) {
           ...action.payload
         ]
       }
-    case "UPDATE_ITEM_LIST":
+    case "UPDATE_ITEM_LIST": {
       const listToUpdate = state.itemLists.find(list => list.id === action.payload.id)
       listToUpdate[action.payload.type].ingredients = action.payload[action.payload.type].ingredients;
       return {
         ...state,
         itemLists: state.itemLists
       }
+    }
+    case "UPDATE_INGREDIENT_CHECKBOX": {
+      // payload should have ingredientId + checkbox state to update it to. Also itemlistId
+      const listToUpdate = state.itemLists.find(list => list.id === action.payload.itemListId)
+      const ingredientToUpdate = listToUpdate.shoppingDetails.ingredients.find(ingredient => ingredient.id === action.payload.ingredientId)
+      ingredientToUpdate.checked = action.payload.checked;
+      return {
+        ...state,
+        itemLists: state.itemLists
+      }
+    }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`)
     }

--- a/src/user-context.js
+++ b/src/user-context.js
@@ -28,7 +28,8 @@ function userDataReducer (state, action) {
       }
     case "UPDATE_ITEM_LIST": {
       const listToUpdate = state.itemLists.find(list => list.id === action.payload.id)
-      listToUpdate[action.payload.type].ingredients = action.payload[action.payload.type].ingredients;
+      listToUpdate.pantryDetails.ingredients = action.payload.pantryDetails.ingredients;
+      listToUpdate.shoppingDetails.ingredients = action.payload.shoppingDetails.ingredients;
       return {
         ...state,
         itemLists: state.itemLists

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,8 @@ export interface Recipe {
   status?: Status["code"],
 }
 export interface Ingredient {
+  index: number,
+  itemListId?: string,
   quantity: string,
   unit: string,
   ingredient: string,

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,7 @@ export interface Recipe {
   status?: Status["code"],
 }
 export interface Ingredient {
-  index: number,
+  id: string,
   itemListId?: string,
   quantity: string,
   unit: string,


### PR DESCRIPTION
This update allows ingredients to be moved between pages. 

Pantry ingredients can be "reordered", which moves them over to the shopping list. 

Ingredients on the shopping list can be checked off one by one. Upon clicking the "Update List" button, all ingredients will be moved over to the Pantry.

Fixes: 
- #19 
- #20 